### PR TITLE
Fix input; show both intercept & plateau

### DIFF
--- a/dlw/DLWSubject.py
+++ b/dlw/DLWSubject.py
@@ -175,7 +175,7 @@ class DLWSubject:
 
     def __init__(self, d_meas, o18_meas, sample_datetimes, dose_weights, mixed_dose, dose_enrichments,
                  subject_weights, subject_id, in_permil=True, pop_avg_rdil=None, expo_calc=False, rq = STANDARD_RQ,
-                 fat_free_mass_factor = DEFAULT_FAT_FREE_MASS_FACTOR):
+                 fat_free_mass_factor = None):
         """Constructor for the DLWSubject class
            :param d_meas (np.array): deuterium delta values of subject samples
            :param o18_meas (np.array): oxygen 18 delta values of subject samples
@@ -191,6 +191,7 @@ class DLWSubject:
            :param rq ([float]): respiratory quotient of subject
            :param fat_free_mass_factor ([float]): fat free mass factor of the subject
         """
+        fat_free_mass_factor = DEFAULT_FAT_FREE_MASS_FACTOR if fat_free_mass_factor is None else fat_free_mass_factor
         if len(d_meas) == len(o18_meas) == len(sample_datetimes) - 1:
 
             self.sample_datetimes = sample_datetimes

--- a/dlw/web/app.py
+++ b/dlw/web/app.py
@@ -71,7 +71,6 @@ def calculate_from_inputs():
             }
         }
 
-    # TODO dont need these in expo
     if np.isnan(CALCULATED_RESULTS.d_ratio_percent):
         plateau_2h = ["2H plateau (<5%)", "N/A (missing data)"]
     else:

--- a/dlw/web/app.py
+++ b/dlw/web/app.py
@@ -55,6 +55,23 @@ def calculate_from_inputs():
             }
         }
 
+    def sort_body_comp_results(results: DLWSubject):
+        return {
+            "plat": {
+                "body_water_avg_kg": ["Total Body Water Average (kg)", round(results.total_body_water_ave_kg_plat, 1)],
+                "fat_free_mass_kg": ["Fat Free Mass (kg)", round(results.fat_free_mass_kg_plat, 1)],
+                "fat_mass_kg": ["Fat Mass (kg)", round(results.fat_mass_kg_plat, 1)],
+                "body_fat_percentage": ["Body Fat Percentage", round(results.body_fat_percent_plat, 1)]
+            },
+            "int": {
+                "body_water_avg_kg": ["Total Body Water Average (kg)", round(results.total_body_water_ave_kg_int, 1)],
+                "fat_free_mass_kg": ["Fat Free Mass (kg)", round(results.fat_free_mass_kg_int, 1)],
+                "fat_mass_kg": ["Fat Mass (kg)", round(results.fat_mass_kg_int, 1)],
+                "body_fat_percentage": ["Body Fat Percentage", round(results.body_fat_percent_int, 1)]
+            }
+        }
+
+    # TODO dont need these in expo
     if np.isnan(CALCULATED_RESULTS.d_ratio_percent):
         plateau_2h = ["2H plateau (<5%)", "N/A (missing data)"]
     else:
@@ -77,11 +94,7 @@ def calculate_from_inputs():
                 "kd_hr": ["kd/hour", round(CALCULATED_RESULTS.kd_per_hr, 6)],
                 "nop_kg": ["NoP (kg)", round(CALCULATED_RESULTS.no['adj_plat_avg_kg'], 1)],
                 "ko_hr": ["ko/hour", round(CALCULATED_RESULTS.ko_per_hr, 6)],
-                "body_water_avg_kg": ["Total Body Water Average (kg)",
-                                      round(CALCULATED_RESULTS.total_body_water_ave_kg, 1)],
-                "fat_free_mass_kg": ["Fat Free Mass (kg)", round(CALCULATED_RESULTS.fat_free_mass_kg, 1)],
-                "fat_mass_kg": ["Fat Mass (kg)", round(CALCULATED_RESULTS.fat_mass_kg, 1)],
-                "body_fat_percentage": ["Body Fat Percentage", round(CALCULATED_RESULTS.body_fat_percent, 1)]
+                "body_comp": sort_body_comp_results(CALCULATED_RESULTS)
             },
             "error_flags": {
                 "plateau_2h": plateau_2h,

--- a/dlw/web/app.py
+++ b/dlw/web/app.py
@@ -37,7 +37,7 @@ def calculate_from_inputs():
                                     pop_avg_rdil=float(input_data['pop_avg_rdil']) if input_data[
                                         'pop_avg_rdil'] else None,
                                     fat_free_mass_factor=float(input_data['fat_free_mass_factor'])
-                                     if input_data['fat_free_mass_factor'] else None)
+                                        if 'fat_free_mass_factor' in input_data and input_data['fat_free_mass_factor'] != "" else None)
 
     def sort_calculated_results(results):
         return {

--- a/dlw/web/src/DLWApp.tsx
+++ b/dlw/web/src/DLWApp.tsx
@@ -35,6 +35,13 @@ interface RCO2_RESULTS {
     ee_mj_day: string[]
 }
 
+interface BODY_COMP_RESULTS {
+    body_water_avg_kg: string[],
+    fat_free_mass_kg: string[],
+    fat_mass_kg: string[],
+    body_fat_percentage: string[]
+}
+
 export interface Results {
     results: {
         calculations: {
@@ -42,10 +49,10 @@ export interface Results {
             kd_hr: string[],
             nop_kg: string[],
             ko_hr: string[],
-            body_water_avg_kg: string[],
-            fat_free_mass_kg: string[],
-            fat_mass_kg: string[],
-            body_fat_percentage: string[]
+            body_comp: {
+                plat: BODY_COMP_RESULTS,
+                int: BODY_COMP_RESULTS
+            }
         }
         speakman2020: {
             rco2_ee_int: RCO2_RESULTS, rco2_ee_plat: RCO2_RESULTS
@@ -278,6 +285,9 @@ export class DLWApp extends React.Component<any, DLWState> {
             let results_speakman_int: JSX.Element[] = [];
             let results_speakman_plat: JSX.Element[] = [];
 
+            let results_body_comp_int: JSX.Element[] = [];
+            let results_body_comp_plat: JSX.Element[] = [];
+
             results_calculations.push(
                 <div className='result-pair'>
                     <p className="result-label">{this.state.results.results.calculations.ndp_kg[0] + ":"}</p>
@@ -298,26 +308,33 @@ export class DLWApp extends React.Component<any, DLWState> {
                     <p className="result-label">{this.state.results.results.calculations.ko_hr[0] + ":"}</p>
                     <p className="result-value">{this.state.results.results.calculations.ko_hr[1]}</p>
                 </div>);
-            results_calculations.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.calculations.body_water_avg_kg[0] + ":"}</p>
-                    <p className="result-value">{this.state.results.results.calculations.body_water_avg_kg[1] + " kg"}</p>
-                </div>);
-            results_calculations.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.calculations.fat_free_mass_kg[0] + ":"}</p>
-                    <p className="result-value">{this.state.results.results.calculations.fat_free_mass_kg[1] + " kg"}</p>
-                </div>);
-            results_calculations.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.calculations.fat_mass_kg[0] + ":"}</p>
-                    <p className="result-value">{this.state.results.results.calculations.fat_mass_kg[1] + " kg"}</p>
-                </div>);
-            results_calculations.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.calculations.body_fat_percentage[0] + ":"}</p>
-                    <p className="result-value">{this.state.results.results.calculations.body_fat_percentage[1] + "%"}</p>
-                </div>);
+            
+            //@ts-ignore
+            function push_body_comp_results(element: JSX.Element[], result_set: BODY_COMP_RESULTS) {
+                element.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{result_set.body_water_avg_kg[0] + ":"}</p>
+                        <p className="result-value">{result_set.body_water_avg_kg[1] + " kg"}</p>
+                    </div>);
+                element.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{result_set.fat_free_mass_kg[0] + ":"}</p>
+                        <p className="result-value">{result_set.fat_free_mass_kg[1] + " kg"}</p>
+                    </div>);
+                element.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{result_set.fat_mass_kg[0] + ":"}</p>
+                        <p className="result-value">{result_set.fat_mass_kg[1] + " kg"}</p>
+                    </div>);
+                element.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{result_set.body_fat_percentage[0] + ":"}</p>
+                        <p className="result-value">{result_set.body_fat_percentage[1] + "%"}</p>
+                    </div>);
+            }
+
+            push_body_comp_results(results_body_comp_int, this.state.results.results.calculations.body_comp.int);
+            push_body_comp_results(results_body_comp_plat, this.state.results.results.calculations.body_comp.plat);
 
             //@ts-ignore
             function push_calculated_results(element: JSX.Element[], result_set: RCO2_RESULTS) {
@@ -348,20 +365,23 @@ export class DLWApp extends React.Component<any, DLWState> {
 
             let error_okay = "error-okay";
             let outside_error_bars = "error-not-okay";
-            let error_class = ((parseFloat(this.state.results.results.error_flags.plateau_2h[1]) < 5 &&
-                parseFloat(this.state.results.results.error_flags.plateau_2h[1]) > -5) ? error_okay : outside_error_bars);
-            results_error_flags.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.error_flags.plateau_2h[0] + ":"}</p>
-                    <p className={"result-value " + error_class}>{this.state.results.results.error_flags.plateau_2h[1]}</p>
-                </div>);
-            error_class = ((parseFloat(this.state.results.results.error_flags.plateau_18O[1]) < 5 &&
-                parseFloat(this.state.results.results.error_flags.plateau_18O[1]) > -5) ? error_okay : outside_error_bars);
-            results_error_flags.push(
-                <div className='result-pair'>
-                    <p className="result-label">{this.state.results.results.error_flags.plateau_18O[0] + ":"}</p>
-                    <p className={"result-value " + error_class}>{this.state.results.results.error_flags.plateau_18O[1]}</p>
-                </div>);
+            let error_class = "";
+            if (!this.state.exponential) {
+                error_class = ((parseFloat(this.state.results.results.error_flags.plateau_2h[1]) < 5 &&
+                    parseFloat(this.state.results.results.error_flags.plateau_2h[1]) > -5) ? error_okay : outside_error_bars);
+                results_error_flags.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{this.state.results.results.error_flags.plateau_2h[0] + ":"}</p>
+                        <p className={"result-value " + error_class}>{this.state.results.results.error_flags.plateau_2h[1]}</p>
+                    </div>);
+                error_class = ((parseFloat(this.state.results.results.error_flags.plateau_18O[1]) < 5 &&
+                    parseFloat(this.state.results.results.error_flags.plateau_18O[1]) > -5) ? error_okay : outside_error_bars);
+                results_error_flags.push(
+                    <div className='result-pair'>
+                        <p className="result-label">{this.state.results.results.error_flags.plateau_18O[0] + ":"}</p>
+                        <p className={"result-value " + error_class}>{this.state.results.results.error_flags.plateau_18O[1]}</p>
+                    </div>);
+            }
             error_class = ((parseFloat(this.state.results.results.error_flags.ds_ratio[1]) < 1.070 &&
                 parseFloat(this.state.results.results.error_flags.ds_ratio[1]) > 1) ? error_okay : outside_error_bars);
             results_error_flags.push(
@@ -412,7 +432,7 @@ export class DLWApp extends React.Component<any, DLWState> {
             } else {
                 // first, middle and last dates, approx
                 for (let i = 0; i < this.state.num_sample_times; i++) {
-                    if (!this.state.excluded_samples[i]) {
+                    if (i === 0 || !this.state.excluded_samples[i - 1]) {
                         chart_data_dates.push(this.state.datetimes[i]);
                     }
                 }
@@ -467,6 +487,20 @@ export class DLWApp extends React.Component<any, DLWState> {
                             <div className='result-section error-flags'>
                                 <h5 className='result-header-error'>Error Flags</h5>
                                 {results_error_flags}
+                            </div>
+                        </div>
+                    </Card>
+                    <Card className='results-card'>
+                        <div className='result-sections calculation-types'>
+                            <div className='s2020'>
+                                <div className='calc-result'>
+                                    <h5 className='result-header-calc'>Body Comp, intercept method</h5>
+                                    {results_body_comp_int}
+                                </div>
+                                <div className='calc-result'>
+                                    <h5 className='result-header-calc'>Body Comp, plateau method</h5>
+                                    {results_body_comp_plat}
+                                </div>
                             </div>
                         </div>
                     </Card>


### PR DESCRIPTION
When the exponential method is selected, automatically use the intercept method to calculate total body water, dilution space ratio, and rCo2 and energy expenditure
The 2H and 18O plateau error flags are then irrelevant and should not be displayed
 

When the two-point method is used, display the TBW and body comp calculations using both the plateau and intercept method. rCo2 and EE are already presented for the plateau and intercept methods, so it would be consistent to present the body comp data using both methods